### PR TITLE
fixed the manifest file and ensures firefox/chrome/edge support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,6 +16,10 @@
         }
     ],
     "web_accessible_resources": [
-        "files/twitter.ico"
+	{
+            "resources": [ "files/twitter.ico" ],
+            "matches": ["*://*.twitter.com/*"],
+            "extension_ids": ["*"]
+	}
     ]
 }

--- a/xbegone.js
+++ b/xbegone.js
@@ -4,7 +4,17 @@ observer.observe(document.body, {
     subtree: true
 });
 
+var the_browser = undefined 
+
 async function init() {
+    if (typeof chrome !== "undefined") {
+        if (typeof browser !== "undefined") {
+            the_browser = browser
+        } else {
+            the_browser = chrome
+        }
+    }
+
     const logo = document.querySelector("header svg");
 
     if (logo) {
@@ -22,6 +32,6 @@ function replaceLogo(logo) {
 function replaceFavicon() {
     const favicon = document.createElement("link");
     favicon.rel = "icon";
-    favicon.href = browser.runtime.getURL("files/twitter.ico");
+    favicon.href = the_browser.runtime.getURL("files/twitter.ico");
     document.head.appendChild(favicon);
 }


### PR DESCRIPTION
fix: invalid manifest v3 resources for Chrome v114 & harden support for chrome/firefox/edge

The matches, or extension_ids key must be specified or else Chrome will fail parsing the v3 manifest file. This was missed when creating this manifest earlier.

I also added a global variable which stores the browser namespace to ensure support for both Chrome and Firefox, as I noticed that the use of the `browser.*` namespace in Chrome throws some error. It is my understanding that Firefox natively supports using the `chrome.*` namespace, so it might be better just to use the `chrome.*` namespace in both

Thought it'd be nice for this to be merged, thanks. Please advise.