### PR TITLE
Fix for twitter URL update

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
     },
     "content_scripts": [
         {
-            "matches": ["*://*.twitter.com/*"],
+            "matches": ["*://*.twitter.com/*","*://*.x.com/*"],
             "js": ["xbegone.js"]
         }
     ],

--- a/manifest.json
+++ b/manifest.json
@@ -18,7 +18,7 @@
     "web_accessible_resources": [
         {
             "resources": ["files/twitter.ico"],
-            "matches": ["*://*.twitter.com/*"],
+            "matches": ["*://*.twitter.com/*","*://*.x.com/*"],
             "extension_ids": ["*"]
         }
     ]


### PR DESCRIPTION
Adds "://.x.com/*" to matches for content scripts and web accessible resources.